### PR TITLE
Added toSvg2 to specify error correction level

### DIFF
--- a/demo/Main.elm
+++ b/demo/Main.elm
@@ -1,12 +1,11 @@
 module Main exposing (..)
 
-
 import Html exposing (..)
 import Html.Attributes exposing (type_)
 import Html.Events exposing (onClick, onInput, onSubmit)
 import Html.Lazy exposing (lazy)
 import QRCode
-
+import QRCode.Encode as Encode exposing (ECLevel)
 
 
 type alias Model =
@@ -65,9 +64,12 @@ view { finalMessage } =
 render : String -> Html msg
 render message =
     Html.div []
-        [ QRCode.toSvg message
-            |> \result -> case result of
-                Result.Ok view -> view
-                Result.Err err -> Html.text (toString err)
-        ]
+        [ QRCode.toSvg2 message Encode.Q
+            |> \result ->
+                case result of
+                    Result.Ok view ->
+                        view
 
+                    Result.Err err ->
+                        Html.text (toString err)
+        ]

--- a/src/QRCode.elm
+++ b/src/QRCode.elm
@@ -1,13 +1,11 @@
-module QRCode exposing (toSvg)
-
+module QRCode exposing (toSvg, toSvg2)
 
 {-| QR Code encoder and renderer.
 
 # Rendering
-@docs toSvg
+@docs toSvg, toSvg2
 
 -}
-
 
 import Html exposing (Html)
 import QRCode.Encode as Encode exposing (ECLevel)
@@ -16,12 +14,10 @@ import QRCode.Error exposing (Error)
 import QRCode.View as View
 
 
-
 toMatrix : String -> ECLevel -> Result Error Model
 toMatrix inputStr ecLevel =
     Encode.encode inputStr ecLevel
         |> Result.andThen Matrix.apply
-
 
 
 {-| Transform a string into a result Error or svg element.
@@ -38,13 +34,18 @@ qrCode =
             Result.Err err -> Html.text (toString err)
 ```
 
-**Tip**: You can determine the size of the generated svg setting 
+**Tip**: You can determine the size of the generated svg setting
 `width` and `height` styles.
 -}
-
-
 toSvg : String -> Result Error (Html msg)
 toSvg inputStr =
     toMatrix inputStr Encode.Q
         |> Result.map View.toSvg
 
+
+{-| Transform a string with given EC level into a result Error or svg element.
+-}
+toSvg2 : String -> ECLevel -> Result Error (Html msg)
+toSvg2 inputStr ecLevel =
+    toMatrix inputStr ecLevel
+        |> Result.map View.toSvg


### PR DESCRIPTION
The current exposed ``toSvg`` function doesn't allow the user to change the error correction level, even though this is supported at a lower level by the library. This new function exposes that important functionality.