### PR TITLE
Prevent lines between rects when rendering to SVG

### DIFF
--- a/src/QRCode/Render/Svg.elm
+++ b/src/QRCode/Render/Svg.elm
@@ -3,7 +3,7 @@ module QRCode.Render.Svg exposing (view)
 import Html exposing (Html)
 import QRCode.Matrix as Matrix
 import Svg exposing (rect, svg)
-import Svg.Attributes exposing (fill, height, viewBox, width, x, y)
+import Svg.Attributes exposing (fill, height, shapeRendering, viewBox, width, x, y)
 
 
 moduleSize : Int
@@ -31,6 +31,7 @@ view matrix =
             [ width sizePx
             , height sizePx
             , viewBox ("0 0 " ++ sizePx ++ " " ++ sizePx)
+            , shapeRendering "crispEdges"
             ]
 
 


### PR DESCRIPTION
By turning off antialiasing using `shape-rendering="crispEdges"` on the SVG-element

Before:
![qrcode-before](https://user-images.githubusercontent.com/3090888/54711664-b18d4780-4b4a-11e9-97f4-17f90a4328ba.png)

After:
![qrcode-after](https://user-images.githubusercontent.com/3090888/54711662-b18d4780-4b4a-11e9-83a4-74ee00359ed0.png)