### PR TITLE
Remove quiet zone when rendering SVG

### DIFF
--- a/src/QRCode/Render/Svg.elm
+++ b/src/QRCode/Render/Svg.elm
@@ -14,11 +14,8 @@ moduleSize =
 view : Matrix.Model -> Html msg
 view matrix =
     let
-        quietZone =
-            8 * moduleSize
-
         sizePx =
-            String.fromInt (List.length matrix * moduleSize + quietZone)
+            String.fromInt (List.length matrix * moduleSize)
     in
     matrix
         |> List.indexedMap
@@ -37,8 +34,7 @@ view matrix =
 moduleView : Int -> Int -> Bool -> Maybe (Html msg)
 moduleView rowIndex colIndex isDark =
     if isDark then
-        -- Add 4 considering quiet zone
-        Just (rectView (rowIndex + 4) (colIndex + 4))
+        Just (rectView rowIndex colIndex)
 
     else
         Nothing


### PR DESCRIPTION
Make the qrcode take up the full space of the SVG, leaving the choice to add a padding/margin to the user.

Wasn't sure whether you'd think this was a good idea and wanted to ask about it, but since it was a small change, I thought I'd start a PR instead of an issue :innocent: 