### PR TITLE
Don't explicitly set width/height attributes in SVG

### DIFF
--- a/src/QRCode/Render/Svg.elm
+++ b/src/QRCode/Render/Svg.elm
@@ -60,9 +60,7 @@ viewBase quietZoneSize matrix =
                 ]
            )
         |> svg
-            [ width sizePx
-            , height sizePx
-            , viewBox ("0 0 " ++ sizePx ++ " " ++ sizePx)
+            [ viewBox ("0 0 " ++ sizePx ++ " " ++ sizePx)
             , shapeRendering "crispEdges"
             , Svg.Attributes.stroke "#000"
             , Svg.Attributes.strokeWidth (String.fromInt moduleSize ++ "px")


### PR DESCRIPTION
You don't know how the SVG QR code is displayed in prior - in most cases SVG is used in responsive design and its size (width/height) is specified as relative units (e.g. %, em, vw, ...).  Setting the default value by the image itself is not sensible (although library users can override via CSS).