### PR TITLE
Avoid using inline "style" attribute be compatible with Content-Security-Policy style-src

### DIFF
--- a/src/QRCode/Render/Svg.elm
+++ b/src/QRCode/Render/Svg.elm
@@ -55,7 +55,7 @@ viewBase quietZoneSize extraAttrs matrix =
                         ++ String.fromFloat (toFloat quietZonePx + (toFloat moduleSize / 2))
                         ++ ")"
                         |> Svg.Attributes.transform
-                    , Svg.Attributes.style "stroke-width: 5px"
+                    , Svg.Attributes.strokeWidth "5px"
                     ]
                     []
                 ]


### PR DESCRIPTION
Unfortunately, the use of `style` attribute in https://github.com/pablohirafuji/elm-qrcode/pull/14 caused errors in apps that need [Content-Security-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src)

> Inline style attributes are also blocked:
> ```html
> <div style="display:none">Foo</div>
> ```

before | after
-- | --
<img width="1392" alt="qr-before" src="https://user-images.githubusercontent.com/473/175760402-06d15486-5f7c-4ee4-979c-bc48b5ead829.png"> | <img width="1392" alt="qr-after" src="https://user-images.githubusercontent.com/473/175760397-6910c2fc-1eaf-493e-9417-bda8ad700066.png">

