### PR TITLE
Remove dependency on elm-community/list-extra

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -14,7 +14,6 @@
         "elm/html": "1.0.0 <= v < 2.0.0",
         "elm/regex": "1.0.0 <= v < 2.0.0",
         "elm/svg": "1.0.0 <= v < 2.0.0",
-        "elm-community/list-extra": "8.2.0 <= v < 9.0.0",
         "justgook/elm-image": "5.0.0 <= v < 6.0.0"
     },
     "test-dependencies": {

--- a/src/QRCode/Encode/Alphanumeric.elm
+++ b/src/QRCode/Encode/Alphanumeric.elm
@@ -4,7 +4,6 @@ module QRCode.Encode.Alphanumeric exposing
     )
 
 import Dict exposing (Dict)
-import List.Extra as List
 import QRCode.Error exposing (Error(..))
 import Regex exposing (Regex)
 
@@ -31,7 +30,7 @@ encode str =
     List.foldr (Result.map2 (::))
         (Ok [])
         (List.map toBinary
-            (List.greedyGroupsOf 2 (String.toList str))
+            (greedyGroupsOf2 (String.toList str))
         )
 
 
@@ -109,3 +108,21 @@ alphanumericCodes =
         , ( '/', 43 )
         , ( ':', 44 )
         ]
+
+
+greedyGroupsOf2 : List a -> List (List a)
+greedyGroupsOf2 list =
+    greedyGroupsOf2Help [] list
+
+
+greedyGroupsOf2Help : List (List a) -> List a -> List (List a)
+greedyGroupsOf2Help acc list =
+    case list of
+        [] ->
+            List.reverse acc
+
+        v1 :: v2 :: rest ->
+            greedyGroupsOf2Help ([ v1, v2 ] :: acc) rest
+
+        _ ->
+            List.reverse (list :: acc)

--- a/src/QRCode/Encode/Numeric.elm
+++ b/src/QRCode/Encode/Numeric.elm
@@ -3,7 +3,6 @@ module QRCode.Encode.Numeric exposing
     , isValid
     )
 
-import List.Extra as List
 import QRCode.Error exposing (Error(..))
 import QRCode.Helpers exposing (breakStr, listResult)
 import Regex exposing (Regex)
@@ -31,7 +30,7 @@ encode str =
     List.foldr (Result.map2 (::))
         (Ok [])
         (List.map encodeHelp
-            (List.greedyGroupsOf 3 (String.toList str))
+            (greedyGroupsOf3 (String.toList str))
         )
 
 
@@ -58,3 +57,21 @@ numericLength str =
 
         _ ->
             10
+
+
+greedyGroupsOf3 : List a -> List (List a)
+greedyGroupsOf3 list =
+    greedyGroupsOf3Help [] list
+
+
+greedyGroupsOf3Help : List (List a) -> List a -> List (List a)
+greedyGroupsOf3Help acc list =
+    case list of
+        [] ->
+            List.reverse acc
+
+        v1 :: v2 :: v3 :: rest ->
+            greedyGroupsOf3Help ([ v1, v2, v3 ] :: acc) rest
+
+        _ ->
+            List.reverse (list :: acc)

--- a/src/QRCode/Render/Svg.elm
+++ b/src/QRCode/Render/Svg.elm
@@ -1,7 +1,6 @@
 module QRCode.Render.Svg exposing (view, viewWithoutQuietZone)
 
 import Html exposing (Html)
-import List.Extra as ListE
 import QRCode.Matrix as Matrix
 import Svg exposing (svg)
 import Svg.Attributes exposing (fill, height, shapeRendering, viewBox, width, x, y)


### PR DESCRIPTION
Hi! Thank you for this library!

I removed the dependency on elm-community/list-extra. It felt a bit excessive to rely on such a big package for just one function :)

This version should be ever so slightly faster as well, since I don’t use `List.take` and `List.drop` like list-extra does under the hood.

I have run the tests, and they pass. I also tried making mistakes in the `greedyGroupsOf2` and `greedyGroupsOf3` functions and the tests failed as expected.